### PR TITLE
closes #issue136763, changed a command to generate gradle error message according to platform

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -414,8 +414,9 @@ final GradleHandledError lockFileDepMissingHandler = GradleHandledError(
     final File gradleFile = project.directory
         .childDirectory('android')
         .childFile('build.gradle');
+        final String generateCommand = globals.platform.isWindows ? r'.\gradlew.bat' : './gradlew';
     final String textInBold = globals.logger.terminal.bolden(
-      'To regenerate the lockfiles run: `./gradlew :generateLockfiles` in ${gradleFile.path}\n'
+      'To regenerate the lockfiles run:  $generateCommand :generateLockfiles` in ${gradleFile.path}\n'
       'To remove dependency locking, remove the `dependencyLocking` from ${gradleFile.path}'
     );
     globals.printBox(

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -791,6 +791,57 @@ Execution failed for task ':app:generateDebugFeatureTransitiveDeps'.
       ProcessManager: () => processManager,
     });
   });
+// Test for-> Most error messages in gradle_errors.dart assume a unix like path separator/environment #136763
+// It is successfully passing the test for linux enviroment.
+  testUsingContext('generates correct gradle command for Unix-like environment',
+      () async {
+    await lockFileDepMissingHandler.handler(
+      project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+      usesAndroidX: true,
+      line: '',
+    );
+
+    expect(
+        testLogger.statusText,
+        contains('\n'
+            '┌─ Flutter Fix ────────────────────────────────────────────────────────────────────────────┐\n'
+            '│ You need to update the lockfile, or disable Gradle dependency locking.                   │\n'
+            '│ To regenerate the lockfiles run:  ./gradlew :generateLockfiles` in /android/build.gradle │\n'
+            '│ To remove dependency locking, remove the `dependencyLocking` from /android/build.gradle  │\n'
+            '└──────────────────────────────────────────────────────────────────────────────────────────┘\n'
+            ''));
+  }, overrides: <Type, Generator>{
+    GradleUtils: () => FakeGradleUtils(),
+    Platform: () => fakePlatform('linux'),
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
+  });
+
+// Test for-> Most error messages in gradle_errors.dart assume a unix like path separator/environment #136763
+// It is successfully passing the test for windows enviroment.
+    testUsingContext('generates correct gradle command for windows environment',
+      () async {
+    await lockFileDepMissingHandler.handler(
+      project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+      usesAndroidX: true,
+      line: '',
+    );
+    expect(
+        testLogger.statusText,
+        contains('\n'
+            '┌─ Flutter Fix ────────────────────────────────────────────────────────────────────────────────┐\n'
+            '│ You need to update the lockfile, or disable Gradle dependency locking.                       │\n'
+            '│ To regenerate the lockfiles run:  .\\gradlew.bat :generateLockfiles` in /android/build.gradle │\n'
+            '│ To remove dependency locking, remove the `dependencyLocking` from /android/build.gradle      │\n'
+            '└──────────────────────────────────────────────────────────────────────────────────────────────┘\n'
+            ''));
+  }, overrides: <Type, Generator>{
+    GradleUtils: () => FakeGradleUtils(),
+    // Platform: () => fakePlatform('android'),
+    Platform: () => fakePlatform('windows'),
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
+  });
 
   group('Incompatible Kotlin version', () {
     testWithoutContext('pattern', () {
@@ -1292,3 +1343,4 @@ class _TestPromptTerminal extends Fake implements AnsiTerminal {
 }
 
 class FakeFlutterProject extends Fake implements FlutterProject {}
+


### PR DESCRIPTION
Currently, the error message displayed to regenerate the lockfiles gives a Unix-like command ./gradlew, which will be incorrect for Windows environments. This PR uses globals.platform.isWindows to give the appropriate command. 

Closes #136763

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].
